### PR TITLE
Breaking: Turn Z component into a generic property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 geojson = "0.24"
 las = { version = "0.8", features = ["laz"] }
-gdal = { version = "0.15" }
- # gdal = { version = "0.12.0", features = ["bindgen"] }
+# gdal = { version = "0.15", optional = true }
 assert_approx_eq = "1.1.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can read the complete documentation [here](https://docs.rs/startin)
 ```rust
 extern crate startin;
 fn main() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
+    let mut pts = Vec::new();
     pts.push([20.0, 30.0, 2.0]);
     pts.push([120.0, 33.0, 12.5]);
     pts.push([124.0, 222.0, 7.65]);

--- a/examples/example1.rs
+++ b/examples/example1.rs
@@ -51,7 +51,7 @@ fn read_xyz_file() -> Result<Vec<[f64; 3]>, Box<dyn Error>> {
     let mut rdr = csv::ReaderBuilder::new()
         .delimiter(b' ')
         .from_reader(io::stdin());
-    let mut vpts: Vec<[f64; 3]> = Vec::new();
+    let mut vpts = Vec::new();
     for result in rdr.deserialize() {
         let record: CSVPoint = result?;
         vpts.push([record.x, record.y, record.z]);

--- a/examples/example10.rs
+++ b/examples/example10.rs
@@ -47,20 +47,20 @@ fn main() {
     //     println!("Duplicates? none.\n");
     // }
 
-    let _re = dt.insert(&vec, startin::InsertionStrategy::AsIs);
+    let _re = dt.insert(vec, startin::InsertionStrategy::AsIs);
     // let _re = dt.insert(&vec, Some(vec![434366.0, 19722.0, 900289.0, 337914.0]));
     println!("{}", dt);
 }
 
-fn read_xyz_file() -> Result<Vec<[f64; 3]>, Box<dyn Error>> {
+fn read_xyz_file() -> Result<Vec<(f64, f64, f64)>, Box<dyn Error>> {
     let mut rdr = csv::ReaderBuilder::new()
         .delimiter(b' ')
         .from_reader(io::stdin());
-    let mut vpts: Vec<[f64; 3]> = Vec::new();
+    let mut vpts = Vec::new();
     for result in rdr.deserialize() {
         let record: CSVPoint = result?;
         if record.z != -9999.0 {
-            vpts.push([record.x, record.y, record.z]);
+            vpts.push((record.x, record.y, record.z));
         }
     }
     Ok(vpts)

--- a/examples/example11.rs
+++ b/examples/example11.rs
@@ -1,19 +1,19 @@
 extern crate startin;
 
 fn main() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([1.1, 1.07, 12.5]);
-    pts.push([11.0, 1.02, 7.65]);
-    pts.push([11.05, 11.1, 33.0]);
-    pts.push([1.0, 11.0, 21.0]);
-    pts.push([9.0, 5.0, 21.0]);
-    pts.push([12.0, 5.1, 21.0]);
-    pts.push([8.0, 8.0, 21.0]);
-    pts.push([12.0, 8.1, 21.0]);
-    pts.push([4.0, 5.15, 33.0]);
+    let mut pts = Vec::new();
+    pts.push((1.1, 1.07, 12.5));
+    pts.push((11.0, 1.02, 7.65));
+    pts.push((11.05, 11.1, 33.0));
+    pts.push((1.0, 11.0, 21.0));
+    pts.push((9.0, 5.0, 21.0));
+    pts.push((12.0, 5.1, 21.0));
+    pts.push((8.0, 8.0, 21.0));
+    pts.push((12.0, 8.1, 21.0));
+    pts.push((4.0, 5.15, 33.0));
 
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
 
     let mut _re = dt.remove(7);
     _re = dt.remove(2);

--- a/examples/example2.rs
+++ b/examples/example2.rs
@@ -1,16 +1,16 @@
 extern crate startin;
 
 fn main() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([20 as f64, 30.0, 0.0]);
-    pts.push([20 as f64, 30.0, 1.1]);
-    pts.push([120.0, 33.0, 12.5]);
-    pts.push([124.0, 222.0, 7.65]);
-    pts.push([20.0, 133.0, 21.0]);
-    pts.push([60.0, 60.0, 33.0]);
+    let mut pts = Vec::new();
+    pts.push((20 as f64, 30.0, 0.0));
+    pts.push((20 as f64, 30.0, 1.1));
+    pts.push((120.0, 33.0, 12.5));
+    pts.push((124.0, 222.0, 7.65));
+    pts.push((20.0, 133.0, 21.0));
+    pts.push((60.0, 60.0, 33.0));
 
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
 
     println!("*****");
     println!("Number of points in DT: {}", dt.number_of_vertices());
@@ -20,7 +20,7 @@ fn main() {
     for (i, each) in dt.all_vertices().iter().enumerate() {
         // skip the first one, the infinite vertex
         if i > 0 {
-            println!("#{}: ({:.3}, {:.3}, {:.3})", i, each[0], each[1], each[2]);
+            println!("#{}: ({:.3}, {:.3}, {:.3})", i, each.0, each.1, each.2);
         }
     }
 

--- a/examples/example4.rs
+++ b/examples/example4.rs
@@ -3,18 +3,18 @@ use rand::prelude::*;
 
 fn main() {
     let num_pts = 1000;
-    let mut pts: Vec<[f64; 3]> = Vec::new();
+    let mut pts = Vec::new();
 
     let mut rng = rand::thread_rng();
     for _i in 0..num_pts {
         let x: f64 = rng.gen();
         let y: f64 = rng.gen();
-        pts.push([x * 100.0, y * 100.0, 2.0]);
+        pts.push((x * 100.0, y * 100.0, 2.0));
     }
 
     let mut dt = startin::Triangulation::new();
     dt.set_jump_and_walk(false);
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     println!("{}", dt.printme(false));
 
     //-- delete 5 vertices on convex hull

--- a/examples/example5.rs
+++ b/examples/example5.rs
@@ -1,17 +1,17 @@
 extern crate startin;
 
 fn main() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 12.5]);
-    pts.push([1.0, 0.0, 7.65]);
-    pts.push([1.1, 1.1, 33.0]);
-    pts.push([0.0, 1.0, 33.0]);
-    pts.push([0.5, 0.9, 33.0]);
-    pts.push([0.9, 0.5, 33.0]);
-    pts.push([0.67, 0.66, 33.0]);
+    let mut pts = Vec::new();
+    pts.push((0.0, 0.0, 12.5));
+    pts.push((1.0, 0.0, 7.65));
+    pts.push((1.1, 1.1, 33.0));
+    pts.push((0.0, 1.0, 33.0));
+    pts.push((0.5, 0.9, 33.0));
+    pts.push((0.9, 0.5, 33.0));
+    pts.push((0.67, 0.66, 33.0));
     let mut dt = startin::Triangulation::new();
     dt.set_jump_and_walk(false);
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     println!("{}", dt.printme(true));
 
     // let _re = dt.remove(3);

--- a/examples/example7.rs
+++ b/examples/example7.rs
@@ -8,18 +8,18 @@ fn main() {
             break;
         }
         let num_pts = 20;
-        let mut pts: Vec<[f64; 3]> = Vec::new();
+        let mut pts = Vec::new();
 
         let mut rng = rand::thread_rng();
         for _i in 0..num_pts {
             let x: f64 = rng.gen();
             let y: f64 = rng.gen();
-            pts.push([x * 100.0, y * 100.0, 2.0]);
+            pts.push((x * 100.0, y * 100.0, 2.0));
         }
 
         let mut dt = startin::Triangulation::new();
         dt.set_jump_and_walk(false);
-        dt.insert(&pts, startin::InsertionStrategy::AsIs);
+        dt.insert(pts.clone(), startin::InsertionStrategy::AsIs);
         // println!("{}", dt.printme(false));
 
         loop {
@@ -28,7 +28,7 @@ fn main() {
                 let _re = dt.remove(j);
                 if dt.is_valid() == false {
                     for p in pts {
-                        println!("{} {} {}", p[0], p[1], p[2]);
+                        println!("{} {} {}", p.0, p.1, p.2);
                         // s.push_str(&format!("\t{:?}\n", self.stars[i].pt));
                     }
                     println!("vertex === {}", j);

--- a/examples/example9.rs
+++ b/examples/example9.rs
@@ -1,24 +1,24 @@
 extern crate startin;
 
 fn main() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 0.125]);
-    pts.push([0.0, 0.0, 0.1111]);
-    pts.push([1.0, 0.0, 0.2222]);
-    pts.push([1.0, 1.0, 0.3333]);
-    pts.push([0.0, 1.0, 0.440]);
-    pts.push([0.5, 0.49, 0.440]);
-    pts.push([0.45, 0.69, 0.440]);
-    pts.push([0.65, 0.49, 0.440]);
-    pts.push([0.75, 0.29, 0.440]);
-    pts.push([1.5, 1.49, 0.440]);
-    pts.push([0.6, 0.2, 0.440]);
-    pts.push([0.45, 0.4, 0.440]);
-    pts.push([0.1, 0.8, 0.440]);
+    let mut pts = Vec::new();
+    pts.push((0.0, 0.0, 0.125));
+    pts.push((0.0, 0.0, 0.1111));
+    pts.push((1.0, 0.0, 0.2222));
+    pts.push((1.0, 1.0, 0.3333));
+    pts.push((0.0, 1.0, 0.440));
+    pts.push((0.5, 0.49, 0.440));
+    pts.push((0.45, 0.69, 0.440));
+    pts.push((0.65, 0.49, 0.440));
+    pts.push((0.75, 0.29, 0.440));
+    pts.push((1.5, 1.49, 0.440));
+    pts.push((0.6, 0.2, 0.440));
+    pts.push((0.45, 0.4, 0.440));
+    pts.push((0.1, 0.8, 0.440));
 
     let mut dt = startin::Triangulation::new();
 
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
 
     // let re = dt.interpolate_nn(2., 1.);
     // let re = dt.interpolate_nn(11., 11.);

--- a/examples/geotiff2tin.rs
+++ b/examples/geotiff2tin.rs
@@ -22,7 +22,7 @@ fn main() {
     // println!("rasterband y-size: {:?}", rasterband.y_size());
     // println!("no_data: {:?}", rasterband.no_data_value());
 
-    // let mut pts: Vec<[f64; 3]> = Vec::new();
+    // let mut pts = Vec::new();
 
     // let nodatavalue = rasterband.no_data_value().unwrap();
     // let xsize = rasterband.x_size();

--- a/examples/geotiff2tin.rs
+++ b/examples/geotiff2tin.rs
@@ -1,70 +1,70 @@
-extern crate gdal;
-extern crate startin;
+// extern crate gdal;
+// extern crate startin;
 
-use gdal::raster::RasterBand;
-use gdal::{Dataset, Metadata};
+// use gdal::raster::RasterBand;
+// use gdal::{Dataset, Metadata};
 
 fn main() {
-    let path = std::env::args()
-        .skip(1)
-        .next()
-        .expect("Must provide a path to a GeoTIFF file");
-    let dataset = Dataset::open(path).unwrap();
+    // let path = std::env::args()
+    //     .skip(1)
+    //     .next()
+    //     .expect("Must provide a path to a GeoTIFF file");
+    // let dataset = Dataset::open(path).unwrap();
 
-    println!("Reading GeoTIFF file: {:?}", dataset.description());
-    println!("CRS: {:?}", dataset.geo_transform());
-    let crs = dataset.geo_transform().unwrap();
+    // println!("Reading GeoTIFF file: {:?}", dataset.description());
+    // println!("CRS: {:?}", dataset.geo_transform());
+    // let crs = dataset.geo_transform().unwrap();
 
-    let rasterband: RasterBand = dataset.rasterband(1).unwrap();
+    // let rasterband: RasterBand = dataset.rasterband(1).unwrap();
 
-    println!("rasterband offset: {:?}", rasterband.offset());
-    println!("rasterband x-size: {:?}", rasterband.x_size());
-    println!("rasterband y-size: {:?}", rasterband.y_size());
-    println!("no_data: {:?}", rasterband.no_data_value());
+    // println!("rasterband offset: {:?}", rasterband.offset());
+    // println!("rasterband x-size: {:?}", rasterband.x_size());
+    // println!("rasterband y-size: {:?}", rasterband.y_size());
+    // println!("no_data: {:?}", rasterband.no_data_value());
 
-    let mut pts: Vec<[f64; 3]> = Vec::new();
+    // let mut pts: Vec<[f64; 3]> = Vec::new();
 
-    let nodatavalue = rasterband.no_data_value().unwrap();
-    let xsize = rasterband.x_size();
-    let ysize = rasterband.y_size();
-    //-- for each line, starting from the top-left
-    for j in 0..ysize {
-        if let Ok(rv) =
-            rasterband.read_as::<f64>((0, j.try_into().unwrap()), (xsize, 1), (xsize, 1), None)
-        {
-            for (i, each) in rv.data.iter().enumerate() {
-                let x = crs[0] + (i as f64 * crs[1]) + crs[1];
-                let y = crs[3] + (j as f64 * crs[5]) + crs[5];
-                let z = each;
-                if *z != nodatavalue {
-                    pts.push([x, y, *z]);
-                }
-            }
-        }
-    }
+    // let nodatavalue = rasterband.no_data_value().unwrap();
+    // let xsize = rasterband.x_size();
+    // let ysize = rasterband.y_size();
+    // //-- for each line, starting from the top-left
+    // for j in 0..ysize {
+    //     if let Ok(rv) =
+    //         rasterband.read_as::<f64>((0, j.try_into().unwrap()), (xsize, 1), (xsize, 1), None)
+    //     {
+    //         for (i, each) in rv.data.iter().enumerate() {
+    //             let x = crs[0] + (i as f64 * crs[1]) + crs[1];
+    //             let y = crs[3] + (j as f64 * crs[5]) + crs[5];
+    //             let z = each;
+    //             if *z != nodatavalue {
+    //                 pts.push([x, y, *z]);
+    //             }
+    //         }
+    //     }
+    // }
 
-    let mut dt = startin::Triangulation::new();
-    // dt.set_jump_and_walk(true);
-    // let bbox = [
-    //     crs[0],
-    //     crs[3] + (ysize as f64 * crs[5]),
-    //     crs[0] + (xsize as f64 * crs[1]),
-    //     crs[3],
-    // ];
-    // dt.insert_with_bbox(&pts, &bbox);
-    dt.insert(&pts, startin::InsertionStrategy::BBox);
+    // let mut dt = startin::Triangulation::new();
+    // // dt.set_jump_and_walk(true);
+    // // let bbox = [
+    // //     crs[0],
+    // //     crs[3] + (ysize as f64 * crs[5]),
+    // //     crs[0] + (xsize as f64 * crs[1]),
+    // //     crs[3],
+    // // ];
+    // // dt.insert_with_bbox(&pts, &bbox);
+    // dt.insert(&pts, startin::InsertionStrategy::BBox);
 
-    println!("Number of points in DT: {}", dt.number_of_vertices());
-    println!("Number of triangles in DT: {}", dt.number_of_triangles());
-    println!("bbox: {:?}", dt.get_bbox());
+    // println!("Number of points in DT: {}", dt.number_of_vertices());
+    // println!("Number of triangles in DT: {}", dt.number_of_triangles());
+    // println!("bbox: {:?}", dt.get_bbox());
 
-    dt.vertical_exaggeration(2.0);
-    // let _re = dt.write_geojson("/Users/hugo/temp/g1.geojson".to_string());
-    let pathout = "/Users/hugo/temp/out.obj";
-    println!("Writing OBJ file...");
-    let re = dt.write_obj(pathout.to_string());
-    match re {
-        Ok(_x) => println!("--> OBJ output saved to: {}", pathout),
-        Err(_x) => println!("ERROR: path {} doesn't exist, abort.", pathout),
-    }
+    // dt.vertical_exaggeration(2.0);
+    // // let _re = dt.write_geojson("/Users/hugo/temp/g1.geojson".to_string());
+    // let pathout = "/Users/hugo/temp/out.obj";
+    // println!("Writing OBJ file...");
+    // let re = dt.write_obj(pathout.to_string());
+    // match re {
+    //     Ok(_x) => println!("--> OBJ output saved to: {}", pathout),
+    //     Err(_x) => println!("ERROR: path {} doesn't exist, abort.", pathout),
+    // }
 }

--- a/examples/readme_snippet.rs
+++ b/examples/readme_snippet.rs
@@ -1,20 +1,20 @@
 extern crate startin;
 
 fn main() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([20.0, 30.0, 2.0]);
-    pts.push([120.0, 33.0, 12.5]);
-    pts.push([124.0, 222.0, 7.65]);
-    pts.push([20.0, 133.0, 21.0]);
-    pts.push([60.0, 60.0, 33.0]);
+    let mut pts: Vec<(f64, f64, f64)> = Vec::new();
+    pts.push((20.0, 30.0, 2.0));
+    pts.push((120.0, 33.0, 12.5));
+    pts.push((124.0, 222.0, 7.65));
+    pts.push((20.0, 133.0, 21.0));
+    pts.push((60.0, 60.0, 33.0));
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     println!("{}", dt);
     //-- print all the vertices
     for (i, each) in dt.all_vertices().iter().enumerate() {
         // skip the first one, the infinite vertex
         if i > 0 {
-            println!("#{}: ({:.3}, {:.3}, {:.3})", i, each[0], each[1], each[2]);
+            println!("#{}: ({:.3}, {:.3}, {:.3})", i, each.0, each.1, each.2);
         }
     }
     //-- insert a new vertex

--- a/src/geom/mod.rs
+++ b/src/geom/mod.rs
@@ -148,7 +148,7 @@ pub fn incircle_fast(a: &[f64], b: &[f64], c: &[f64], p: &[f64]) -> i8 {
     }
 }
 
-pub fn bbox2d(pts: &Vec<[f64; 3]>) -> [f64; 4] {
+pub fn bbox2d(pts: &[[f64; 2]]) -> [f64; 4] {
     let mut re: [f64; 4] = [std::f64::MAX, std::f64::MAX, std::f64::MIN, std::f64::MIN];
     for each in pts {
         if each[0] < re[0] {

--- a/tests/deletion.rs
+++ b/tests/deletion.rs
@@ -3,19 +3,20 @@ use startin;
 
 #[test]
 fn simple() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([1.1, 1.07, 12.5]);
-    pts.push([11.0, 1.02, 7.65]);
-    pts.push([11.05, 11.1, 33.0]);
-    pts.push([1.0, 11.0, 21.0]);
-    pts.push([9.0, 5.0, 21.0]);
-    pts.push([12.0, 5.1, 21.0]);
-    pts.push([8.0, 8.0, 21.0]);
-    pts.push([12.0, 8.1, 21.0]);
-    pts.push([4.0, 5.15, 33.0]);
+    let pts = vec![
+        (1.1, 1.07, 12.5),
+        (11.0, 1.02, 7.65),
+        (11.05, 11.1, 33.0),
+        (1.0, 11.0, 21.0),
+        (9.0, 5.0, 21.0),
+        (12.0, 5.1, 21.0),
+        (8.0, 8.0, 21.0),
+        (12.0, 8.1, 21.0),
+        (4.0, 5.15, 33.0),
+    ];
     let mut dt = startin::Triangulation::new();
     dt.set_jump_and_walk(false);
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     let _re = dt.remove(7);
     assert_eq!(8, dt.number_of_vertices());
     assert_eq!(8, dt.number_of_triangles());
@@ -23,17 +24,17 @@ fn simple() {
 
 #[test]
 fn insert_delete() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
+    let mut pts = vec![];
     let mut rng = rand::thread_rng();
     let size = 10.0_f64;
     for _i in 0..100 {
         let x: f64 = rng.gen();
         let y: f64 = rng.gen();
-        pts.push([x * size, y * size, 2.0]);
+        pts.push((x * size, y * size, 2.0));
     }
     let mut dt = startin::Triangulation::new();
     dt.set_jump_and_walk(false);
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     let _re = dt.insert_one_pt(3.05, 3.1, 33.0);
     let re = dt.remove(dt.number_of_vertices() - 1);
     assert_eq!(true, re.is_ok());
@@ -43,17 +44,17 @@ fn insert_delete() {
 
 #[test]
 fn insert_delete_them_many() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
+    let mut pts = vec![];
     let mut rng = rand::thread_rng();
     let size = 10.0_f64;
     for _i in 0..10 {
         let x: f64 = rng.gen();
         let y: f64 = rng.gen();
-        pts.push([x * size, y * size, 2.0]);
+        pts.push((x * size, y * size, 2.0));
     }
     let mut dt = startin::Triangulation::new();
     dt.set_jump_and_walk(false);
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     assert_eq!(10, dt.number_of_vertices());
     for i in 5..10 {
         let _re = dt.remove(i);
@@ -66,14 +67,14 @@ fn insert_delete_them_many() {
 
 #[test]
 fn collinear() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 12.5]);
-    pts.push([1.0, 0.0, 7.65]);
-    pts.push([2.0, 0.0, 33.0]);
-    pts.push([3.0, 0.0, 33.0]);
-    pts.push([4.0, 0.0, 33.0]);
+    let mut pts = vec![];
+    pts.push((0.0, 0.0, 12.5));
+    pts.push((1.0, 0.0, 7.65));
+    pts.push((2.0, 0.0, 33.0));
+    pts.push((3.0, 0.0, 33.0));
+    pts.push((4.0, 0.0, 33.0));
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     assert_eq!(5, dt.number_of_vertices());
     assert_eq!(0, dt.number_of_triangles());
     let _re = dt.insert_one_pt(3.0, 3.0, 33.0);
@@ -83,13 +84,13 @@ fn collinear() {
 
 #[test]
 fn convexhull() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 12.5]);
-    pts.push([1.0, 0.0, 7.65]);
-    pts.push([2.0, 2.0, 33.0]);
-    pts.push([0.0, 2.0, 33.0]);
+    let mut pts = vec![];
+    pts.push((0.0, 0.0, 12.5));
+    pts.push((1.0, 0.0, 7.65));
+    pts.push((2.0, 2.0, 33.0));
+    pts.push((0.0, 2.0, 33.0));
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     let _re = dt.remove(3);
     assert_eq!(3, dt.number_of_vertices());
     assert_eq!(1, dt.number_of_triangles());
@@ -100,17 +101,17 @@ fn convexhull() {
 
 #[test]
 fn cocircular() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 12.5]);
-    pts.push([1.0, 0.0, 7.65]);
-    pts.push([1.0, 1.0, 33.0]);
-    pts.push([0.0, 1.0, 21.0]);
+    let mut pts = vec![];
+    pts.push((0.0, 0.0, 12.5));
+    pts.push((1.0, 0.0, 7.65));
+    pts.push((1.0, 1.0, 33.0));
+    pts.push((0.0, 1.0, 21.0));
     let y: f64 = 0.5 + ((0.5 * 0.5 + 0.5 * 0.5) as f64).sqrt();
-    pts.push([0.5, y, 21.0]);
-    pts.push([0.5, 0.5, 33.0]);
+    pts.push((0.5, y, 21.0));
+    pts.push((0.5, 0.5, 33.0));
     let mut dt = startin::Triangulation::new();
     dt.set_jump_and_walk(false);
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     let _re = dt.remove(6);
     assert_eq!(5, dt.number_of_vertices());
     assert_eq!(3, dt.number_of_triangles());
@@ -118,14 +119,14 @@ fn cocircular() {
 
 #[test]
 fn deletion_impossible() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([1.1, 1.07, 12.5]);
-    pts.push([11.0, 1.02, 7.65]);
-    pts.push([11.05, 11.1, 33.0]);
-    pts.push([1.0, 11.0, 21.0]);
-    pts.push([9.0, 5.0, 21.0]);
+    let mut pts = vec![];
+    pts.push((1.1, 1.07, 12.5));
+    pts.push((11.0, 1.02, 7.6));
+    pts.push((11.05, 11.1, 33.0));
+    pts.push((1.0, 11.0, 21.0));
+    pts.push((9.0, 5.0, 21.0));
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     assert_eq!(Err(startin::StartinError::VertexInfinite), dt.remove(0));
     assert_eq!(Err(startin::StartinError::VertexUnknown), dt.remove(7));
     let _re = dt.remove(5);
@@ -134,13 +135,13 @@ fn deletion_impossible() {
 
 #[test]
 fn deletion_only_collinear_left() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 1.0]);
-    pts.push([0.0, 1.0, 1.0]);
-    pts.push([0.0, 2.0, 1.0]);
-    pts.push([0.0, 3.0, 1.0]);
+    let mut pts: Vec<(f64, f64, f64)> = Vec::new();
+    pts.push((0.0, 0.0, 1.0));
+    pts.push((0.0, 1.0, 1.0));
+    pts.push((0.0, 2.0, 1.0));
+    pts.push((0.0, 3.0, 1.0));
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     assert!(dt.is_valid());
     assert_eq!(4, dt.number_of_vertices());
     assert_eq!(0, dt.number_of_triangles());
@@ -177,14 +178,14 @@ fn grid() {
 
 #[test]
 fn simple_grid() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 12.5]);
-    pts.push([1.0, 0.0, 7.65]);
-    pts.push([1.0, 1.0, 33.0]);
-    pts.push([0.0, 1.0, 21.0]);
+    let mut pts = Vec::new();
+    pts.push((0.0, 0.0, 12.5));
+    pts.push((1.0, 0.0, 7.65));
+    pts.push((1.0, 1.0, 33.0));
+    pts.push((0.0, 1.0, 21.0));
     let mut dt = startin::Triangulation::new();
     dt.set_jump_and_walk(false);
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     let _re = dt.remove(1);
     let _re = dt.remove(3);
     assert_eq!(2, dt.number_of_vertices());
@@ -193,32 +194,32 @@ fn simple_grid() {
 
 #[test]
 fn get_point() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
+    let mut pts = Vec::new();
     let mut rng = rand::thread_rng();
     let size = 10.0_f64;
     for _i in 0..100 {
         let x: f64 = rng.gen();
         let y: f64 = rng.gen();
-        pts.push([x * size, y * size, 2.0]);
+        pts.push((x * size, y * size, 2.0));
     }
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     let _re = dt.remove(33);
     assert_eq!(Err(startin::StartinError::VertexRemoved), dt.get_point(33));
 }
 
 #[test]
 fn number_vertices() {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
+    let mut pts = Vec::new();
     let mut rng = rand::thread_rng();
     let size = 10.0_f64;
     for _i in 0..100 {
         let x: f64 = rng.gen();
         let y: f64 = rng.gen();
-        pts.push([x * size, y * size, 2.0]);
+        pts.push((x * size, y * size, 2.0));
     }
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     let _re = dt.remove(33);
     let _re = dt.remove(32);
     assert_eq!(101, dt.all_vertices().len());

--- a/tests/init_construction.rs
+++ b/tests/init_construction.rs
@@ -2,7 +2,7 @@ use startin;
 
 #[test]
 fn empty() {
-    let dt = startin::Triangulation::new();
+    let dt = startin::Triangulation::<f64>::new();
     assert_eq!(0, dt.number_of_vertices());
     assert_eq!(0, dt.number_of_triangles());
 }

--- a/tests/interpolate.rs
+++ b/tests/interpolate.rs
@@ -3,18 +3,18 @@ use crate::startin::Triangulation;
 use rand::prelude::*;
 use startin;
 
-fn four_points() -> Triangulation {
-    let mut pts: Vec<[f64; 3]> = Vec::new();
-    pts.push([0.0, 0.0, 1.0]);
-    pts.push([10.0, 0.0, 2.0]);
-    pts.push([10.0, 10.0, 3.0]);
-    pts.push([0.0, 10.0, 4.0]);
+fn four_points() -> Triangulation<f64> {
+    let mut pts = Vec::new();
+    pts.push((0.0, 0.0, 1.0));
+    pts.push((10.0, 0.0, 2.0));
+    pts.push((10.0, 10.0, 3.0));
+    pts.push((0.0, 10.0, 4.0));
     let mut dt = startin::Triangulation::new();
-    dt.insert(&pts, startin::InsertionStrategy::AsIs);
+    dt.insert(pts, startin::InsertionStrategy::AsIs);
     dt
 }
 
-fn random_points_500() -> Triangulation {
+fn random_points_500() -> Triangulation<f64> {
     let mut dt = startin::Triangulation::new();
     let mut rng = rand::thread_rng();
     for _i in 0..500 {
@@ -28,7 +28,7 @@ fn random_points_500() -> Triangulation {
 
 #[test]
 fn empty() {
-    let mut dt = startin::Triangulation::new();
+    let mut dt = startin::Triangulation::<f64>::new();
     let i_nn = startin::interpolation::NN {};
     let i_tin = startin::interpolation::TIN {};
     let i_lap = startin::interpolation::Laplace {};


### PR DESCRIPTION
Closes #18

Hi Hugo! During my work at [Foresight](https://github.com/ForesightMiningSoftwareCorporation) we required a TIN for interpolating various attributes. 

This change would allow storage & interpolation of any additional attributes. 

### Breaking changes
- Points in general are now modeled as tuples rather than arrays, so the last component can be generic.
- In situations with sizable generics, cloning starts to become more expensive. 

### Self diagnose
- Names & api could use some work
- Requires some more examples using different generics, implementing `Attr`.
- `Attr` should be easier to implement. A few less traits are probably possible.  